### PR TITLE
fix(package.json): include Documentation directory with package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "*.meta",
         "*.asmdef",
         "*.xml",
+        "Documentation",
         "Runtime"
     ]
 }


### PR DESCRIPTION
The Documentation directory should be included with the package so
the built package has the required documentation for users to refer
to when the package is installed.