### PR TITLE
fix(HowToGuides): provide correct package name in installation guide

### DIFF
--- a/Documentation/HowToGuides/Installation/README.md
+++ b/Documentation/HowToGuides/Installation/README.md
@@ -69,7 +69,7 @@ The `CameraRigs.UnityXR` prefab provides a spatial camera rig and controller set
 
 ### Done
 
-The `Tilia.CameraRigs.UnityXR` package will now be available in your Unity project `Packages` directory ready for use in your project.
+The `Tilia CameraRigs UnityXR` package will now be available in your Unity project `Packages` directory ready for use in your project.
 
 The package will now also show up in the Unity Package Manager UI. From then on the package can be updated by selecting the package in the Unity Package Manager and clicking on the `Update` button or using the version selection UI.
 


### PR DESCRIPTION
The package name does not include dots and therefore should be written
without any dot separators.