### PR TITLE
fix(Prefabs): tag camera as MainCamera

### DIFF
--- a/Runtime/Prefabs/CameraRigs.UnityXR.prefab
+++ b/Runtime/Prefabs/CameraRigs.UnityXR.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 5927244289758819085}
   m_Layer: 0
   m_Name: HeadAnchor
-  m_TagString: Untagged
+  m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0


### PR DESCRIPTION
The camera within the rig has now been tagged with the MainCamera tag
as it would be considered the main camera in the scene by default.