### PR TITLE
feat(API): add auto-generated API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 [Ll]ibrary/
 [Tt]emp/
 [Oo]bj/
+[Oo]bj.meta
 [Bb]uild/
 [Bb]uilds/
 [Ll]ogs/

--- a/Documentation/API.meta
+++ b/Documentation/API.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 75142c7b52e10d24db7aff9e5a3416a8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/README.md
+++ b/Documentation/API/README.md
@@ -1,0 +1,9 @@
+# Namespace Tilia.CameraRigs.UnityXR
+
+### Classes
+
+#### [UnityXRConfigurator]
+
+Provides a way to configure settings within the Unity Engine in XR namespace.
+
+[UnityXRConfigurator]: UnityXRConfigurator.md

--- a/Documentation/API/README.md.meta
+++ b/Documentation/API/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fc7bb974c4d964e4e965b75c18e10077
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/UnityXRConfigurator.md
+++ b/Documentation/API/UnityXRConfigurator.md
@@ -1,0 +1,133 @@
+# Class UnityXRConfigurator
+
+Provides a way to configure settings within the Unity Engine in XR namespace.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [LockPhysicsUpdateRateToRenderFrequency]
+  * [TrackingSpaceType]
+* [Methods]
+  * [OnAfterLockPhysicsUpdateRateToRenderFrequencyChange()]
+  * [OnAfterTrackingSpaceTypeChange()]
+  * [OnEnable()]
+  * [Update()]
+  * [UpdateFixedDeltaTime()]
+  * [UpdateTrackingSpaceType()]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* UnityXRConfigurator
+
+##### Namespace
+
+* [Tilia.CameraRigs.UnityXR]
+
+##### Syntax
+
+```
+public class UnityXRConfigurator : MonoBehaviour
+```
+
+### Properties
+
+#### LockPhysicsUpdateRateToRenderFrequency
+
+Automatically set the Unity Physics Fixed Timestep value based on the headset render frequency.
+
+##### Declaration
+
+```
+public bool LockPhysicsUpdateRateToRenderFrequency { get; set; }
+```
+
+#### TrackingSpaceType
+
+Represents the type of physical space available for XR.
+
+##### Declaration
+
+```
+public TrackingSpaceType TrackingSpaceType { get; set; }
+```
+
+### Methods
+
+#### OnAfterLockPhysicsUpdateRateToRenderFrequencyChange()
+
+Called after [LockPhysicsUpdateRateToRenderFrequency] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterLockPhysicsUpdateRateToRenderFrequencyChange()
+```
+
+#### OnAfterTrackingSpaceTypeChange()
+
+Called after [TrackingSpaceType] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterTrackingSpaceTypeChange()
+```
+
+#### OnEnable()
+
+##### Declaration
+
+```
+protected virtual void OnEnable()
+```
+
+#### Update()
+
+##### Declaration
+
+```
+protected virtual void Update()
+```
+
+#### UpdateFixedDeltaTime()
+
+Updates the fixed delta time to the appropriate value.
+
+##### Declaration
+
+```
+protected virtual void UpdateFixedDeltaTime()
+```
+
+#### UpdateTrackingSpaceType()
+
+Updates the tracking space type.
+
+##### Declaration
+
+```
+protected virtual void UpdateTrackingSpaceType()
+```
+
+[Tilia.CameraRigs.UnityXR]: README.md
+[LockPhysicsUpdateRateToRenderFrequency]: UnityXRConfigurator.md#LockPhysicsUpdateRateToRenderFrequency
+[TrackingSpaceType]: UnityXRConfigurator.md#TrackingSpaceType
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[LockPhysicsUpdateRateToRenderFrequency]: #LockPhysicsUpdateRateToRenderFrequency
+[TrackingSpaceType]: #TrackingSpaceType
+[Methods]: #Methods
+[OnAfterLockPhysicsUpdateRateToRenderFrequencyChange()]: #OnAfterLockPhysicsUpdateRateToRenderFrequencyChange
+[OnAfterTrackingSpaceTypeChange()]: #OnAfterTrackingSpaceTypeChange
+[OnEnable()]: #OnEnable
+[Update()]: #Update
+[UpdateFixedDeltaTime()]: #UpdateFixedDeltaTime
+[UpdateTrackingSpaceType()]: #UpdateTrackingSpaceType

--- a/Documentation/API/UnityXRConfigurator.md.meta
+++ b/Documentation/API/UnityXRConfigurator.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 43f3577fb0daec346a904c8af7e0b5ef
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,60 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "Runtime/**.cs"
+          ]
+        }
+      ],
+      "dest": "_TEMP_DOCS/API",
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "_TEMP_DOCS/API/**.yml",
+          "_TEMP_DOCS/API/index.md"
+        ]
+      },
+      {
+        "files": [
+          "*.md"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+        ]
+      }
+    ],
+    "overwrite": [
+      {
+        "files": [
+          "apidoc/**.md"
+        ],
+        "exclude": [
+          "obj/**",
+          "_site/**"
+        ]
+      }
+    ],
+    "dest": "_TEMP_DOCS/output",
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "template": [
+      "default"
+    ],
+    "postProcessors": [],
+    "markdownEngineName": "markdig",
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": false,
+    "disableGitFeatures": false
+  }
+}

--- a/docfx.json.meta
+++ b/docfx.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e5da985b16d0bf048a7f2310a55a5d26
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The API documentation is auto generated with docfx and converted to
markdown via turndown in a custom nodejs script.