### PR TITLE
fix(prefabs): track center eye source for head anchor

### DIFF
--- a/Runtime/Prefabs/CameraRigs.UnityXR.prefab
+++ b/Runtime/Prefabs/CameraRigs.UnityXR.prefab
@@ -192,7 +192,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Device: 0
-  m_PoseSource: 3
+  m_PoseSource: 2
   m_PoseProviderComponent: {fileID: 0}
   m_TrackingType: 0
   m_UpdateType: 0


### PR DESCRIPTION
The HeadAnchor was originally tracking the Pose Source of Head, but
Unity now warns that if the Pose Source is attached to a camera and
not tracking `Center Eye - HMD Reference` that there may be tracking
issues. So it has been switched over to reduce the possibility of
issues with tracking.