### PR TITLE
fix(docs): update docs to mention deprecation of Unity legacy XR system

### DIFF
--- a/Documentation/HowToGuides/AddingAUnityXRCameraRig/README.md
+++ b/Documentation/HowToGuides/AddingAUnityXRCameraRig/README.md
@@ -10,6 +10,8 @@
 
 The `CameraRigs.UnityXR` prefab provides a camera that tracks the HMD rotation and position along with any available XR controllers. This utilizes the underlying [Unity] provided functionality for accessing the connected hardware.
 
+> The legacy XR management system was deprecated in Unity `2019.3.0f1`, please use the [Tilia.CameraRigs.XRPluginFramework.Unity] package for support with the new Unity XR Plugin Framework.
+
 ## Prerequisites
 
 * [Install the Tilia.CameraRigs.UnityXR] package dependency in to your Unity project.
@@ -44,3 +46,4 @@ Now you have a UnityXR CameraRig in your scene. If you play the Unity scene you 
 
 [Install the Tilia.CameraRigs.UnityXR]: ../Installation/README.md
 [Unity]: https://unity3d.com/
+[Tilia.CameraRigs.XRPluginFramework.Unity]: https://github.com/ExtendRealityLtd/Tilia.CameraRigs.XRPluginFramework.Unity

--- a/Documentation/HowToGuides/Installation/README.md
+++ b/Documentation/HowToGuides/Installation/README.md
@@ -8,7 +8,9 @@
 
 ## Introduction
 
-The `CameraRigs.UnityXR` prefab provides a spatial camera rig and controller setup utilizing the default UnityXR framework. This prefab can be included in a [Unity] software project via the [Unity Package Manager].
+The `CameraRigs.UnityXR` prefab provides a spatial camera rig and controller setup utilizing the legacy XR management system in the Unity software. This prefab can be included in a [Unity] software project via the [Unity Package Manager].
+
+> The legacy XR management system was deprecated in Unity `2019.3.0f1`, please use the [Tilia.CameraRigs.XRPluginFramework.Unity] package for support with the new Unity XR Plugin Framework.
 
 ## Let's Start
 
@@ -79,3 +81,4 @@ The package will now also show up in the Unity Package Manager UI. From then on 
 [Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.CameraRigs.UnityXR.svg
 [Releases]: ../../../../../releases
 [Latest-Release]: ../../../../../releases/latest
+[Tilia.CameraRigs.XRPluginFramework.Unity]: https://github.com/ExtendRealityLtd/Tilia.CameraRigs.XRPluginFramework.Unity

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Tilia logo][Tilia-Image]](#)
 
 > ### CameraRigs -> UnityXR
-> A camera rig prefab utilizing the UnityXR framework.
+> A camera rig prefab utilizing the legacy XR management system for the Unity software.
 
 [![Release][Version-Release]][Releases]
 [![License][License-Badge]][License]
@@ -10,6 +10,10 @@
 ## Introduction
 
 The UnityXR camera rig provides a basis for a spatial camera rig that tracks a HMD and up to two controllers (left/right) utilizing the built in SDK support by the [Unity] software.
+
+This is built upon the [legacy XR management system] within previous versions of the Unity software that was deprecated in Unity `2019.3.0f1` and replaced with the newer Unity [XR Plugin Framework].
+
+See the [Tilia.CameraRigs.XRPluginFramework.Unity] repository for a camera rig that utilizes this newer Unity XR Plugin Framework.
 
 > **Requires** the Unity software version `2018.3.10f1` (or above).
 
@@ -51,3 +55,6 @@ Code released under the [MIT License][License].
 [Code of Conduct]: https://github.com/ExtendRealityLtd/.github/blob/master/CODE_OF_CONDUCT.md
 
 [Unity]: https://unity3d.com/
+[legacy XR management system]: https://docs.unity3d.com/2018.3/Documentation/Manual/VROverview.html
+[XR Plugin Framework]: https://docs.unity3d.com/2019.3/Documentation/Manual/XR.html
+[Tilia.CameraRigs.XRPluginFramework.Unity]: https://github.com/ExtendRealityLtd/Tilia.CameraRigs.XRPluginFramework.Unity

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "io.extendreality.tilia.camerarigs.unityxr",
     "displayName": "Tilia CameraRigs UnityXR",
-    "description": "A camera rig prefab utilizing the UnityXR components.",
     "version": "1.4.12",
+    "description": "A camera rig prefab utilizing the legacy XR management system for the Unity software.",
     "unity": "2018.3",
     "unityRelease": "10f1",
     "keywords": [


### PR DESCRIPTION
Unity deprecated the XR system in 2019.3 in favour of the new XR Plugin
Framework system. The docs have been updated to reflect this and to
point to another repo that has a camera rig that supports this newer
system.