### PR TITLE
feat(prefab): add device details about headset and controllers

### DIFF
--- a/Documentation/API/README.md
+++ b/Documentation/API/README.md
@@ -6,4 +6,9 @@
 
 Provides a way to configure settings within the Unity Engine in XR namespace.
 
+#### [UnityXRNodeRecord]
+
+Provides the description for a UnityXR CameraRig node element.
+
 [UnityXRConfigurator]: UnityXRConfigurator.md
+[UnityXRNodeRecord]: UnityXRNodeRecord.md

--- a/Documentation/API/UnityXRNodeRecord.md
+++ b/Documentation/API/UnityXRNodeRecord.md
@@ -1,0 +1,238 @@
+# Class UnityXRNodeRecord
+
+Provides the description for a UnityXR CameraRig node element.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Fields]
+  * [lastKnownBatteryStatus]
+  * [lastKnownIsConnected]
+  * [lastKnownTrackingType]
+* [Properties]
+  * [BatteryChargeStatus]
+  * [BatteryLevel]
+  * [IsConnected]
+  * [Manufacturer]
+  * [Model]
+  * [NodeType]
+  * [Priority]
+  * [TrackingType]
+  * [XRNodeType]
+* [Methods]
+  * [HasBatteryChargeStatusChanged()]
+  * [HasIsConnectedChanged()]
+  * [HasTrackingTypeChanged()]
+  * [SetNodeType(Int32)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* UnityXRNodeRecord
+
+##### Namespace
+
+* [Tilia.CameraRigs.UnityXR]
+
+##### Syntax
+
+```
+public class UnityXRNodeRecord : DeviceDetailsRecord
+```
+
+### Fields
+
+#### lastKnownBatteryStatus
+
+The last known battery charge status.
+
+##### Declaration
+
+```
+protected BatteryStatus lastKnownBatteryStatus
+```
+
+#### lastKnownIsConnected
+
+The last known is connected status.
+
+##### Declaration
+
+```
+protected bool lastKnownIsConnected
+```
+
+#### lastKnownTrackingType
+
+The last known tracking type.
+
+##### Declaration
+
+```
+protected SpatialTrackingType lastKnownTrackingType
+```
+
+### Properties
+
+#### BatteryChargeStatus
+
+##### Declaration
+
+```
+public override BatteryStatus BatteryChargeStatus { get; protected set; }
+```
+
+#### BatteryLevel
+
+##### Declaration
+
+```
+public override float BatteryLevel { get; protected set; }
+```
+
+#### IsConnected
+
+##### Declaration
+
+```
+public override bool IsConnected { get; protected set; }
+```
+
+#### Manufacturer
+
+##### Declaration
+
+```
+public override string Manufacturer { get; protected set; }
+```
+
+#### Model
+
+##### Declaration
+
+```
+public override string Model { get; protected set; }
+```
+
+#### NodeType
+
+The source property to match against.
+
+##### Declaration
+
+```
+public XRNode NodeType { get; set; }
+```
+
+#### Priority
+
+##### Declaration
+
+```
+public override int Priority { get; protected set; }
+```
+
+#### TrackingType
+
+##### Declaration
+
+```
+public override SpatialTrackingType TrackingType { get; protected set; }
+```
+
+#### XRNodeType
+
+##### Declaration
+
+```
+public override XRNode XRNodeType { get; protected set; }
+```
+
+### Methods
+
+#### HasBatteryChargeStatusChanged()
+
+##### Declaration
+
+```
+protected override bool HasBatteryChargeStatusChanged()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | n/a |
+
+#### HasIsConnectedChanged()
+
+##### Declaration
+
+```
+protected override bool HasIsConnectedChanged()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | n/a |
+
+#### HasTrackingTypeChanged()
+
+##### Declaration
+
+```
+protected override bool HasTrackingTypeChanged()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | n/a |
+
+#### SetNodeType(Int32)
+
+Sets the [NodeType].
+
+##### Declaration
+
+```
+public virtual void SetNodeType(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the XRNode. |
+
+[Tilia.CameraRigs.UnityXR]: README.md
+[NodeType]: UnityXRNodeRecord.md#NodeType
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Fields]: #Fields
+[lastKnownBatteryStatus]: #lastKnownBatteryStatus
+[lastKnownIsConnected]: #lastKnownIsConnected
+[lastKnownTrackingType]: #lastKnownTrackingType
+[Properties]: #Properties
+[BatteryChargeStatus]: #BatteryChargeStatus
+[BatteryLevel]: #BatteryLevel
+[IsConnected]: #IsConnected
+[Manufacturer]: #Manufacturer
+[Model]: #Model
+[NodeType]: #NodeType
+[Priority]: #Priority
+[TrackingType]: #TrackingType
+[XRNodeType]: #XRNodeType
+[Methods]: #Methods
+[HasBatteryChargeStatusChanged()]: #HasBatteryChargeStatusChanged
+[HasIsConnectedChanged()]: #HasIsConnectedChanged
+[HasTrackingTypeChanged()]: #HasTrackingTypeChanged
+[SetNodeType(Int32)]: #SetNodeTypeInt32

--- a/Documentation/API/UnityXRNodeRecord.md.meta
+++ b/Documentation/API/UnityXRNodeRecord.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fd2a1a7a081b2814b839ad466b42ae71
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs/CameraRigs.UnityXR.prefab
+++ b/Runtime/Prefabs/CameraRigs.UnityXR.prefab
@@ -108,6 +108,8 @@ GameObject:
   - component: {fileID: 3904199790168431191}
   - component: {fileID: 8073922421639309864}
   - component: {fileID: 6778621509180730146}
+  - component: {fileID: 1579268070374954846}
+  - component: {fileID: 8459413459688735757}
   m_Layer: 0
   m_Name: HeadAnchor
   m_TagString: MainCamera
@@ -197,6 +199,47 @@ MonoBehaviour:
   m_TrackingType: 0
   m_UpdateType: 0
   m_UseRelativeTransform: 0
+--- !u!114 &1579268070374954846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 922460200594708716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26195b592fd7b154295e0d3d2965afa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  nodeType: 3
+--- !u!114 &8459413459688735757
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 922460200594708716}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 1579268070374954846}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
 --- !u!1 &1133523771844855127
 GameObject:
   m_ObjectHideFlags: 0
@@ -269,6 +312,8 @@ GameObject:
   m_Component:
   - component: {fileID: 4596733671386802138}
   - component: {fileID: 3194917570776222985}
+  - component: {fileID: 333226132958686735}
+  - component: {fileID: 3105703308570972790}
   m_Layer: 0
   m_Name: RightHandAnchor
   m_TagString: Untagged
@@ -308,6 +353,47 @@ MonoBehaviour:
   m_TrackingType: 0
   m_UpdateType: 0
   m_UseRelativeTransform: 0
+--- !u!114 &333226132958686735
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1351350362042343500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26195b592fd7b154295e0d3d2965afa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  nodeType: 5
+--- !u!114 &3105703308570972790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1351350362042343500}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 333226132958686735}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
 --- !u!1 &1601966238253703875
 GameObject:
   m_ObjectHideFlags: 0
@@ -370,6 +456,52 @@ MonoBehaviour:
   intensity: 0.15
   node: 5
   duration: 0.005
+--- !u!1 &2133854006076104616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4704062962229177216}
+  - component: {fileID: 3610771784536213690}
+  m_Layer: 0
+  m_Name: MomentProcessor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4704062962229177216
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2133854006076104616}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6612597725703812162}
+  m_Father: {fileID: 6250577539179111349}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3610771784536213690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2133854006076104616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c0eab237e25807459af1c5caf4d3d33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  processMoment: 3
+  processes: {fileID: 712732527542787942}
 --- !u!1 &2293735143216331159
 GameObject:
   m_ObjectHideFlags: 0
@@ -618,6 +750,82 @@ MonoBehaviour:
   intensity: 0.15
   node: 4
   duration: 0.005
+--- !u!1 &3351416633964134423
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6612597725703812162}
+  - component: {fileID: 712732527542787942}
+  m_Layer: 0
+  m_Name: ListContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6612597725703812162
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3351416633964134423}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4704062962229177216}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &712732527542787942
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3351416633964134423}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15a9c53f0e146454cb669c38817bd5b7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements:
+  - {fileID: 5995425104727812049}
+  - {fileID: 8459413459688735757}
+  - {fileID: 496545317774832904}
+  - {fileID: 3105703308570972790}
 --- !u!1 &3406371639979523009
 GameObject:
   m_ObjectHideFlags: 0
@@ -861,6 +1069,8 @@ GameObject:
   m_Component:
   - component: {fileID: 4294790287048619111}
   - component: {fileID: 1850819188307584090}
+  - component: {fileID: 7801932568729669707}
+  - component: {fileID: 496545317774832904}
   m_Layer: 0
   m_Name: LeftHandAnchor
   m_TagString: Untagged
@@ -900,6 +1110,47 @@ MonoBehaviour:
   m_TrackingType: 0
   m_UpdateType: 0
   m_UseRelativeTransform: 0
+--- !u!114 &7801932568729669707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3802095207536524125}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 26195b592fd7b154295e0d3d2965afa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  nodeType: 4
+--- !u!114 &496545317774832904
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3802095207536524125}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 7801932568729669707}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
 --- !u!1 &4319714544062664181
 GameObject:
   m_ObjectHideFlags: 0
@@ -1225,6 +1476,8 @@ GameObject:
   - component: {fileID: 6250577539179111349}
   - component: {fileID: 6500219864934193526}
   - component: {fileID: 3013476052725209540}
+  - component: {fileID: 8649737164339848103}
+  - component: {fileID: 5995425104727812049}
   m_Layer: 0
   m_Name: CameraRigs.UnityXR
   m_TagString: Untagged
@@ -1248,6 +1501,7 @@ Transform:
   - {fileID: 4596733671386802138}
   - {fileID: 1611304897310937274}
   - {fileID: 116809909245343863}
+  - {fileID: 4704062962229177216}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1282,14 +1536,51 @@ MonoBehaviour:
   headsetCamera: {fileID: 3904199790168431191}
   headsetVelocityTracker: {fileID: 3402107918225628765}
   supplementHeadsetCameras: {fileID: 0}
+  headsetDeviceDetails: {fileID: 1579268070374954846}
+  dominantController: {fileID: 8649737164339848103}
   leftController: {fileID: 3802095207536524125}
   leftControllerVelocityTracker: {fileID: 3091238550019444664}
   leftControllerHapticProcess: {fileID: 8589945936993354417}
   leftControllerHapticProfiles: {fileID: 8369763671209325646}
+  leftControllerDeviceDetails: {fileID: 7801932568729669707}
   rightController: {fileID: 1351350362042343500}
   rightControllerVelocityTracker: {fileID: 6048965503992365318}
   rightControllerHapticProcess: {fileID: 4086013424135816009}
   rightControllerHapticProfiles: {fileID: 8810069713607435762}
+  rightControllerDeviceDetails: {fileID: 333226132958686735}
+--- !u!114 &8649737164339848103
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6707005887722074733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7512583a373897b4aa8971c27e3264cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  leftController: {fileID: 7801932568729669707}
+  rightController: {fileID: 333226132958686735}
+  IsChanging:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &5995425104727812049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6707005887722074733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 8649737164339848103}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
 --- !u!1 &7281102756684691949
 GameObject:
   m_ObjectHideFlags: 0
@@ -1342,46 +1633,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0dea9bd4fa4b5cc4b9b36a77382cb3b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements:
   - {fileID: 3108501296213660515}
@@ -1507,46 +1785,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0dea9bd4fa4b5cc4b9b36a77382cb3b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
   Found:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   NotFound:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   IsEmpty:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   IsPopulated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
   Populated:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Added:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Removed:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   Emptied:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: Zinnia.Haptics.Collection.HapticProcessObservableList+UnityEvent,
-      Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   currentIndex: 0
   elements:
   - {fileID: 5210086586808573936}

--- a/Runtime/SharedResources/Scripts/UnityXRNodeRecord.cs
+++ b/Runtime/SharedResources/Scripts/UnityXRNodeRecord.cs
@@ -1,0 +1,153 @@
+﻿namespace Tilia.CameraRigs.UnityXR
+{
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.XmlDocumentationAttribute;
+    using UnityEngine;
+    using UnityEngine.XR;
+    using Zinnia.Extension;
+    using Zinnia.Tracking.CameraRig;
+    using Zinnia.Utility;
+
+    /// <summary>
+    /// Provides the description for a UnityXR CameraRig node element.
+    /// </summary>
+    public class UnityXRNodeRecord : DeviceDetailsRecord
+    {
+        /// <summary>
+        /// The source property to match against.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public XRNode NodeType { get; set; }
+
+        /// <inheritdoc/>
+        public override XRNode XRNodeType
+        {
+            get
+            {
+                return NodeType;
+            }
+            protected set { NodeType = value; }
+        }
+        /// <inheritdoc/>
+        public override bool IsConnected { get => XRDeviceProperties.IsTracked(NodeType); protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override int Priority { get => 0; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override string Manufacturer { get => XRDeviceProperties.Manufacturer(NodeType); protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override string Model
+        {
+            get
+            {
+                if (NodeType == XRNode.Head && !SystemInfo.deviceModel.ToLower().Contains("system product name"))
+                {
+                    return SystemInfo.deviceModel;
+                }
+                else
+                {
+                    return XRDeviceProperties.Model(NodeType);
+
+                }
+            }
+            protected set => throw new System.NotImplementedException();
+        }
+        /// <inheritdoc/>
+        public override SpatialTrackingType TrackingType
+        {
+            get
+            {
+                if (XRDeviceProperties.HasPositionalTracking(NodeType) && XRDeviceProperties.HasRotationalTracking(NodeType))
+                {
+                    return SpatialTrackingType.RotationAndPosition;
+                }
+                else if (XRDeviceProperties.HasRotationalTracking(NodeType))
+                {
+                    return SpatialTrackingType.RotationOnly;
+                }
+                else
+                {
+                    return SpatialTrackingType.None;
+                }
+            }
+            protected set => throw new System.NotImplementedException();
+        }
+        /// <inheritdoc/>
+        public override float BatteryLevel
+        {
+            get
+            {
+                if (NodeType == XRNode.Head)
+                {
+                    return SystemInfo.batteryLevel;
+                }
+                else
+                {
+                    return XRDeviceProperties.BatteryLevel(NodeType);
+
+                }
+            }
+            protected set => throw new System.NotImplementedException();
+        }
+        /// <inheritdoc/>
+        public override BatteryStatus BatteryChargeStatus { get => BatteryStatus.Unknown; protected set => throw new System.NotImplementedException(); }
+
+        /// <summary>
+        /// The last known battery charge status.
+        /// </summary>
+        protected BatteryStatus lastKnownBatteryStatus;
+        /// <summary>
+        /// The last known is connected status.
+        /// </summary>
+        protected bool lastKnownIsConnected;
+        /// <summary>
+        /// The last known tracking type.
+        /// </summary>
+        protected SpatialTrackingType lastKnownTrackingType;
+
+        /// <summary>
+        /// Sets the <see cref="NodeType"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="XRNode"/>.</param>
+        public virtual void SetNodeType(int index)
+        {
+            NodeType = EnumExtensions.GetByIndex<XRNode>(index);
+        }
+
+        /// <inheritdoc/>
+        protected override bool HasBatteryChargeStatusChanged()
+        {
+            bool hasChanged = BatteryChargeStatus != lastKnownBatteryStatus;
+            if (hasChanged)
+            {
+                BatteryChargeStatusChanged?.Invoke(BatteryChargeStatus);
+            }
+            lastKnownBatteryStatus = BatteryChargeStatus;
+            return hasChanged;
+        }
+
+        /// <inheritdoc/>
+        protected override bool HasIsConnectedChanged()
+        {
+            bool hasChanged = IsConnected != lastKnownIsConnected;
+            if (hasChanged)
+            {
+                ConnectionStatusChanged?.Invoke(IsConnected);
+            }
+            lastKnownIsConnected = IsConnected;
+            return hasChanged;
+        }
+
+        /// <inheritdoc/>
+        protected override bool HasTrackingTypeChanged()
+        {
+            bool hasChanged = TrackingType != lastKnownTrackingType;
+            if (hasChanged)
+            {
+                TrackingTypeChanged?.Invoke(TrackingType);
+            }
+            lastKnownTrackingType = TrackingType;
+            return hasChanged;
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/UnityXRNodeRecord.cs.meta
+++ b/Runtime/SharedResources/Scripts/UnityXRNodeRecord.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26195b592fd7b154295e0d3d2965afa9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The new DeviceDetailsRecord has been extended into the
UnityXRNodeRecord that provide information about a UnityXR Node
device and this is now stored on the prefab so it is easily available
at runtime.

The DominantControllerObserver has also been added to the prefab to
make it easier to determine the current dominant controller.