### PR TITLE
feat(UnityXRNodeRecord): simplify record by extending base class

### DIFF
--- a/Runtime/SharedResources/Scripts/UnityXRNodeRecord.cs
+++ b/Runtime/SharedResources/Scripts/UnityXRNodeRecord.cs
@@ -2,16 +2,14 @@
 {
     using Malimbe.PropertySerializationAttribute;
     using Malimbe.XmlDocumentationAttribute;
-    using UnityEngine;
     using UnityEngine.XR;
     using Zinnia.Extension;
     using Zinnia.Tracking.CameraRig;
-    using Zinnia.Utility;
 
     /// <summary>
     /// Provides the description for a UnityXR CameraRig node element.
     /// </summary>
-    public class UnityXRNodeRecord : DeviceDetailsRecord
+    public class UnityXRNodeRecord : BaseDeviceDetailsRecord
     {
         /// <summary>
         /// The Node Type for the record.
@@ -21,86 +19,10 @@
         public XRNode NodeType { get; set; }
 
         /// <inheritdoc/>
-        public override XRNode XRNodeType
-        {
-            get { return NodeType; }
-            protected set { NodeType = value; }
-        }
-        /// <inheritdoc/>
-        public override bool IsConnected { get => XRDeviceProperties.IsTracked(NodeType); protected set => throw new System.NotImplementedException(); }
+        public override XRNode XRNodeType { get { return NodeType; } protected set { NodeType = value; } }
+
         /// <inheritdoc/>
         public override int Priority { get => 0; protected set => throw new System.NotImplementedException(); }
-        /// <inheritdoc/>
-        public override string Manufacturer { get => XRDeviceProperties.Manufacturer(NodeType); protected set => throw new System.NotImplementedException(); }
-        /// <inheritdoc/>
-        public override string Model
-        {
-            get
-            {
-                if (NodeType == XRNode.Head && !SystemInfo.deviceModel.ToLower().Contains("system product name"))
-                {
-                    return SystemInfo.deviceModel;
-                }
-                else
-                {
-                    return XRDeviceProperties.Model(NodeType);
-
-                }
-            }
-            protected set => throw new System.NotImplementedException();
-        }
-        /// <inheritdoc/>
-        public override SpatialTrackingType TrackingType
-        {
-            get
-            {
-                if (XRDeviceProperties.HasPositionalTracking(NodeType) && XRDeviceProperties.HasRotationalTracking(NodeType))
-                {
-                    return SpatialTrackingType.RotationAndPosition;
-                }
-                else if (XRDeviceProperties.HasRotationalTracking(NodeType))
-                {
-                    return SpatialTrackingType.RotationOnly;
-                }
-                else
-                {
-                    return SpatialTrackingType.None;
-                }
-            }
-            protected set => throw new System.NotImplementedException();
-        }
-        /// <inheritdoc/>
-        public override float BatteryLevel
-        {
-            get
-            {
-                if (NodeType == XRNode.Head)
-                {
-                    return SystemInfo.batteryLevel;
-                }
-                else
-                {
-                    return XRDeviceProperties.BatteryLevel(NodeType);
-
-                }
-            }
-            protected set => throw new System.NotImplementedException();
-        }
-        /// <inheritdoc/>
-        public override BatteryStatus BatteryChargeStatus { get => NodeType == XRNode.Head ? SystemInfo.batteryStatus : BatteryStatus.Unknown; protected set => throw new System.NotImplementedException(); }
-
-        /// <summary>
-        /// The last known battery charge status.
-        /// </summary>
-        protected BatteryStatus lastKnownBatteryStatus;
-        /// <summary>
-        /// The last known is connected status.
-        /// </summary>
-        protected bool lastKnownIsConnected;
-        /// <summary>
-        /// The last known tracking type.
-        /// </summary>
-        protected SpatialTrackingType lastKnownTrackingType;
 
         /// <summary>
         /// Sets the <see cref="NodeType"/>.
@@ -109,42 +31,6 @@
         public virtual void SetNodeType(int index)
         {
             NodeType = EnumExtensions.GetByIndex<XRNode>(index);
-        }
-
-        /// <inheritdoc/>
-        protected override bool HasBatteryChargeStatusChanged()
-        {
-            bool hasChanged = BatteryChargeStatus != lastKnownBatteryStatus;
-            if (hasChanged)
-            {
-                BatteryChargeStatusChanged?.Invoke(BatteryChargeStatus);
-            }
-            lastKnownBatteryStatus = BatteryChargeStatus;
-            return hasChanged;
-        }
-
-        /// <inheritdoc/>
-        protected override bool HasIsConnectedChanged()
-        {
-            bool hasChanged = IsConnected != lastKnownIsConnected;
-            if (hasChanged)
-            {
-                ConnectionStatusChanged?.Invoke(IsConnected);
-            }
-            lastKnownIsConnected = IsConnected;
-            return hasChanged;
-        }
-
-        /// <inheritdoc/>
-        protected override bool HasTrackingTypeChanged()
-        {
-            bool hasChanged = TrackingType != lastKnownTrackingType;
-            if (hasChanged)
-            {
-                TrackingTypeChanged?.Invoke(TrackingType);
-            }
-            lastKnownTrackingType = TrackingType;
-            return hasChanged;
         }
     }
 }


### PR DESCRIPTION
The UnityXRNodeRecord now extends the BaseDeviceDetailsRecord which
handles many of the core fuinctions so this class can be simplified.