### PR TITLE
feat(DeviceDetails): add defaults for passthrough camera details

### DIFF
--- a/Documentation/API/UnityXRNodeRecord.md
+++ b/Documentation/API/UnityXRNodeRecord.md
@@ -8,6 +8,7 @@ Provides the description for a UnityXR CameraRig node element.
 * [Namespace]
 * [Syntax]
 * [Properties]
+  * [HasPassThroughCamera]
   * [NodeType]
   * [Priority]
   * [XRNodeType]
@@ -32,6 +33,14 @@ public class UnityXRNodeRecord : BaseDeviceDetailsRecord
 ```
 
 ### Properties
+
+#### HasPassThroughCamera
+
+##### Declaration
+
+```
+public override bool HasPassThroughCamera { get; protected set; }
+```
 
 #### NodeType
 
@@ -83,6 +92,7 @@ public virtual void SetNodeType(int index)
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Properties]: #Properties
+[HasPassThroughCamera]: #HasPassThroughCamera
 [NodeType]: #NodeType
 [Priority]: #Priority
 [XRNodeType]: #XRNodeType

--- a/Runtime/SharedResources/Scripts/UnityXRNodeRecord.cs
+++ b/Runtime/SharedResources/Scripts/UnityXRNodeRecord.cs
@@ -33,6 +33,8 @@
 
         /// <inheritdoc/>
         public override int Priority { get => 0; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override bool HasPassThroughCamera { get => false; protected set => throw new System.NotImplementedException(); }
 
         /// <summary>
         /// Sets the <see cref="NodeType"/>.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "2.6.0"
+        "io.extendreality.zinnia.unity": "2.7.0"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
The DeviceDetailsRecord now supports passthrough camera options and therefore anything that derrives from that needs to implement the base interfaces even if they don't support camera passthrough yet.